### PR TITLE
Feat: 스터디 API 수정, 추가 및 예외처리

### DIFF
--- a/src/main/java/com/donothing/swithme/common/ExceptionAdvice.java
+++ b/src/main/java/com/donothing/swithme/common/ExceptionAdvice.java
@@ -1,0 +1,28 @@
+package com.donothing.swithme.common;
+
+import com.donothing.swithme.dto.response.ErrorMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.NoSuchElementException;
+
+@RestControllerAdvice
+public class ExceptionAdvice {
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ErrorMessage> IllegalStateException(IllegalStateException e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ErrorMessage.builder()
+                        .message(e.getMessage())
+                        .code(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .build());
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<ErrorMessage> NoSuchElementException(NoSuchElementException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorMessage.builder()
+                .message(e.getMessage())
+                .code(HttpStatus.BAD_REQUEST)
+                .build());
+    }
+}

--- a/src/main/java/com/donothing/swithme/controller/BookmarkController.java
+++ b/src/main/java/com/donothing/swithme/controller/BookmarkController.java
@@ -19,7 +19,7 @@ import javax.validation.Valid;
 @RequestMapping("/api/v1/bookmark")
 @RestController
 @RequiredArgsConstructor
-@Api(value = "북마크 관련 API")
+@Api(tags = {"북마크 관련 API"})
 public class BookmarkController {
 
     private final BookmarkService bookmarkService;

--- a/src/main/java/com/donothing/swithme/controller/BookmarkController.java
+++ b/src/main/java/com/donothing/swithme/controller/BookmarkController.java
@@ -10,6 +10,8 @@ import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -24,7 +26,9 @@ public class BookmarkController {
     @PostMapping
     @ApiOperation(value = "북마크 등록", notes = "북마크를 등록하는 API 입니다.")
     public ResponseEntity<ResponseDto<BookmarkRegisterResponseDto>> registerBookmark(@RequestBody @Valid
-                                                                                  BookmarkRegisterRequestDto request) {
+                                                                                        BookmarkRegisterRequestDto request,
+                                                                                     @AuthenticationPrincipal UserDetails user) {
+        request.setMemberId(Long.valueOf(user.getUsername()));
         return new ResponseEntity<>(new ResponseDto<>(201, "북마크 등록 성공",
                 bookmarkService.registerBookmark(request)),
                 HttpStatus.CREATED);

--- a/src/main/java/com/donothing/swithme/controller/StudyController.java
+++ b/src/main/java/com/donothing/swithme/controller/StudyController.java
@@ -50,10 +50,11 @@ public class StudyController {
 
     @PutMapping("/{studyId}")
     @ApiOperation(value = "해당 스터디 수정", notes = "해당 스터디의 정보를 수정하는 API 입니다.")
-    public ResponseEntity<ResponseDto<StudyDetailResponseDto>> updateStudy(@PathVariable String studyId,
-            @RequestBody StudyUpdateRequestDto request) {
+    public ResponseEntity<ResponseDto<Void>> updateStudy(@PathVariable String studyId,
+                                                         @RequestBody @Valid StudyUpdateRequestDto request) {
+        studyService.updateStudy(studyId, request);
         return new ResponseEntity<>(new ResponseDto<>(201, "스터디 수정 성공",
-                studyService.updateStudy(studyId, request)),
+                null),
                 HttpStatus.OK);
     }
 
@@ -67,7 +68,7 @@ public class StudyController {
     @PostMapping("/comment/{studyId}")
     @ApiOperation(value = "해당 스터디에 댓글 등록", notes = "해당 스터디의 댓글을 등록하는 API 입니다.")
     public ResponseEntity<ResponseDto<Void>> comment(@PathVariable String studyId,
-                                                    @RequestBody StudyCommentReqeustDto request,
+                                                     @RequestBody @Valid StudyCommentReqeustDto request,
                                                     @AuthenticationPrincipal UserDetails user) {
         request.setMemberId(Long.valueOf(user.getUsername()));
         studyService.comment(studyId, request);
@@ -78,7 +79,7 @@ public class StudyController {
 
     @PutMapping("/comment")
     @ApiOperation(value = "해당 댓글 수정", notes = "해당 댓글을 수정하는 API 입니다.")
-    public ResponseEntity<ResponseDto<Void>> updateComment(@RequestBody StudyCommentUpdateRequestDto request) {
+    public ResponseEntity<ResponseDto<Void>> updateComment(@RequestBody @Valid StudyCommentUpdateRequestDto request) {
         studyService.updateComment(request);
         return new ResponseEntity<>(new ResponseDto<>(201, "스터디 댓글 수정 성공",
                  null),

--- a/src/main/java/com/donothing/swithme/controller/StudyController.java
+++ b/src/main/java/com/donothing/swithme/controller/StudyController.java
@@ -58,6 +58,19 @@ public class StudyController {
                 HttpStatus.OK);
     }
 
+    @PostMapping("/{studyId}")
+    @ApiOperation(value = "해당 스터디 참여 요청", notes = "해당 스터디에 참여요청을 하는 API 입니다.")
+    public ResponseEntity<ResponseDto<Void>> updateStudy(@PathVariable String studyId,
+                                                         @AuthenticationPrincipal UserDetails user) {
+        studyService.joinStudy(JoinStudyRequest.builder()
+                .studyId(Long.valueOf(studyId))
+                .memberId(Long.valueOf(user.getUsername()))
+                .build());
+        return new ResponseEntity<>(new ResponseDto<>(201, "스터디 수정 성공",
+                null),
+                HttpStatus.OK);
+    }
+
     @GetMapping("/comment/{studyId}")
     @ApiOperation(value = "해당 스터디 댓글 조회", notes = "해당 스터디의 댓글을 조회하는 API 입니다.")
     public ResponseEntity<ResponseDto<List<StudyCommentListResponseDto>>> getCommentList(@PathVariable String studyId) {

--- a/src/main/java/com/donothing/swithme/controller/StudyController.java
+++ b/src/main/java/com/donothing/swithme/controller/StudyController.java
@@ -58,7 +58,7 @@ public class StudyController {
                 HttpStatus.OK);
     }
 
-    @PostMapping("/{studyId}")
+    @PostMapping("/join/{studyId}")
     @ApiOperation(value = "해당 스터디 참여 요청", notes = "해당 스터디에 참여요청을 하는 API 입니다.")
     public ResponseEntity<ResponseDto<Void>> updateStudy(@PathVariable String studyId,
                                                          @AuthenticationPrincipal UserDetails user) {

--- a/src/main/java/com/donothing/swithme/controller/StudyController.java
+++ b/src/main/java/com/donothing/swithme/controller/StudyController.java
@@ -36,7 +36,7 @@ public class StudyController {
 
     @GetMapping
     @ApiOperation(value = "모든 스터디 조회", notes = "스터디를 조회하는 API 입니다.")
-    public Page<Study> getStudies(StudySearchRequest condition, Pageable pageable) {
+    public Page<StudyDetailResponseDto> getStudies(StudySearchRequest condition, Pageable pageable) {
         return studyService.getStudies(condition, pageable);
     }
 

--- a/src/main/java/com/donothing/swithme/controller/StudyController.java
+++ b/src/main/java/com/donothing/swithme/controller/StudyController.java
@@ -66,7 +66,7 @@ public class StudyController {
                 .studyId(Long.valueOf(studyId))
                 .memberId(Long.valueOf(user.getUsername()))
                 .build());
-        return new ResponseEntity<>(new ResponseDto<>(201, "스터디 수정 성공",
+        return new ResponseEntity<>(new ResponseDto<>(201, "스터디 참여요청 성공",
                 null),
                 HttpStatus.OK);
     }

--- a/src/main/java/com/donothing/swithme/domain/MemberStudy.java
+++ b/src/main/java/com/donothing/swithme/domain/MemberStudy.java
@@ -1,5 +1,6 @@
 package com.donothing.swithme.domain;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,4 +27,11 @@ public class MemberStudy {
     private ApproveStatus approveStatus; // 승인여부 [WAIT, APPROVE, DENY]
 
     private LocalDateTime dateOkay; // 스터디 참여승인일자
+
+    @Builder
+    public MemberStudy(Member member, Study study) {
+        this.member = member;
+        this.study = study;
+        this.approveStatus = ApproveStatus.WAIT;
+    }
 }

--- a/src/main/java/com/donothing/swithme/domain/Study.java
+++ b/src/main/java/com/donothing/swithme/domain/Study.java
@@ -31,6 +31,9 @@ public class Study {
     @Column(nullable = false)
     private int numberOfMembers; // 목표 인원수
 
+    @Column(nullable = false)
+    private int remainingNumber; // 참여 가능한 남은 인원수
+
 //    private regionCode; // 지역코드
 
     @Column(columnDefinition = "TEXT", length = 1000)
@@ -44,12 +47,13 @@ public class Study {
     private String dateStudyEnd;
 
     @Builder
-    public Study(Member member, String title, StudyType studyType, int numberOfMembers, String studyInfo,
+    public Study(Member member, String title, StudyType studyType, int numberOfMembers, int remainingNumber, String studyInfo,
             StudyStatus studyStatus, String dateStudyStart, String dateStudyEnd) {
         this.member = member;
         this.title = title;
         this.studyType = studyType;
         this.numberOfMembers = numberOfMembers;
+        this.remainingNumber = remainingNumber;
         this.studyInfo = studyInfo;
         this.studyStatus = studyStatus;
         this.dateStudyStart = dateStudyStart;
@@ -67,4 +71,8 @@ public class Study {
     }
 
     public Study(Long studyId) { this.studyId = studyId; }
+
+    public void decreaseRemainingNumber() {
+        this.remainingNumber -= 1;
+    }
 }

--- a/src/main/java/com/donothing/swithme/dto/bookmark/BookmarkRegisterRequestDto.java
+++ b/src/main/java/com/donothing/swithme/dto/bookmark/BookmarkRegisterRequestDto.java
@@ -3,6 +3,7 @@ package com.donothing.swithme.dto.bookmark;
 import com.donothing.swithme.domain.Bookmark;
 import com.donothing.swithme.domain.Member;
 import com.donothing.swithme.domain.Study;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -16,7 +17,7 @@ public class BookmarkRegisterRequestDto {
     @NotNull(message = "북마크로 등록 될 스터디 아이디는 필수입니다.")
     private Long studyId;
 
-    // TODO: 안보이게 설정하기
+    @ApiModelProperty(hidden = true)
     private Long memberId;
 
     public Bookmark toEntity() {

--- a/src/main/java/com/donothing/swithme/dto/member/MemberInfoResponseDto.java
+++ b/src/main/java/com/donothing/swithme/dto/member/MemberInfoResponseDto.java
@@ -1,5 +1,6 @@
 package com.donothing.swithme.dto.member;
 
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,6 +11,7 @@ public class MemberInfoResponseDto {
     private String nickname;
 
     @Builder
+    @QueryProjection
     public MemberInfoResponseDto(Long memberId, String name, String nickname) {
         this.memberId = memberId;
         this.name = name;

--- a/src/main/java/com/donothing/swithme/dto/response/ErrorMessage.java
+++ b/src/main/java/com/donothing/swithme/dto/response/ErrorMessage.java
@@ -1,0 +1,14 @@
+package com.donothing.swithme.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Builder
+@Getter
+@RequiredArgsConstructor
+public class ErrorMessage {
+    private final HttpStatus code;
+    private final String message;
+}

--- a/src/main/java/com/donothing/swithme/dto/study/JoinStudyRequest.java
+++ b/src/main/java/com/donothing/swithme/dto/study/JoinStudyRequest.java
@@ -1,0 +1,28 @@
+package com.donothing.swithme.dto.study;
+
+import com.donothing.swithme.domain.Member;
+import com.donothing.swithme.domain.MemberStudy;
+import com.donothing.swithme.domain.Study;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class JoinStudyRequest {
+    private Long studyId;
+
+    @ApiModelProperty(hidden = true)
+    private Long memberId;
+
+    public MemberStudy toEntity() {
+        return MemberStudy.builder()
+                .study(new Study(studyId))
+                .member(new Member(memberId))
+                .build();
+    }
+}

--- a/src/main/java/com/donothing/swithme/dto/study/StudyCommentListResponseDto.java
+++ b/src/main/java/com/donothing/swithme/dto/study/StudyCommentListResponseDto.java
@@ -3,6 +3,8 @@ package com.donothing.swithme.dto.study;
 import com.donothing.swithme.domain.Comment;
 import com.donothing.swithme.dto.member.MemberInfoResponseDto;
 import java.util.ArrayList;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -15,12 +17,14 @@ public class StudyCommentListResponseDto {
     private long commentId;
     private MemberInfoResponseDto memberInfo;
     private String comment;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime dateCreated;
     private boolean isDeleted;
-    private List<StudyCommentListResponseDto> recommnet;
+    private List<StudyCommentListResponseDto> recomment;
 
     public StudyCommentListResponseDto(Comment comment, List<Comment> allComments) {
-        List<StudyCommentListResponseDto> recommnet = new ArrayList<>(); // 대댓글을 담을 리스트
+        List<StudyCommentListResponseDto> recomment = new ArrayList<>(); // 대댓글을 담을 리스트
+
         this.commentId = comment.getCommentId();
         this.memberInfo = MemberInfoResponseDto.builder().
                 memberId(comment.getMember().getMemberId()).
@@ -30,15 +34,14 @@ public class StudyCommentListResponseDto {
         this.comment = comment.getComment();
         this.dateCreated = comment.getDateCreated();
         this.commentId = comment.getCommentId();
-        this.commentId = comment.getCommentId();
 
         for (Comment c : allComments) {
             if (c.getCommentTag().equals(comment.getCommentId())) {
-                recommnet.add(new StudyCommentListResponseDto(c));
+                recomment.add(new StudyCommentListResponseDto(c));
             }
         }
 
-        this.recommnet = recommnet;
+        this.recomment = recomment;
     }
 
     public StudyCommentListResponseDto(Comment comment) {
@@ -50,7 +53,6 @@ public class StudyCommentListResponseDto {
                 build();
         this.comment = comment.getComment();
         this.dateCreated = comment.getDateCreated();
-        this.commentId = comment.getCommentId();
         this.commentId = comment.getCommentId();
     }
 }

--- a/src/main/java/com/donothing/swithme/dto/study/StudyCommentReqeustDto.java
+++ b/src/main/java/com/donothing/swithme/dto/study/StudyCommentReqeustDto.java
@@ -4,6 +4,7 @@ import com.donothing.swithme.domain.Comment;
 import com.donothing.swithme.domain.Member;
 import com.donothing.swithme.domain.Study;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,10 +12,12 @@ import javax.validation.constraints.NotNull;
 
 @Getter
 @Setter
+@Builder
 public class StudyCommentReqeustDto {
 
     @ApiModelProperty(value = "대댓글 작성 시 원 댓글 아이디, 본댓글이면 null로 셋팅", example = "1")
     private Long recommentId;
+
     @NotNull(message = "댓글 내용은 필수입니다.")
     @ApiModelProperty(value = "댓글내용", required = true)
     private String comment;
@@ -27,6 +30,7 @@ public class StudyCommentReqeustDto {
                 .member(new Member(memberId))
                 .deletedFlag(false)
                 .study(new Study(studyId))
+                .commentTag(recommentId)
                 .comment(comment)
                 .build();
     }

--- a/src/main/java/com/donothing/swithme/dto/study/StudyDetailResponseDto.java
+++ b/src/main/java/com/donothing/swithme/dto/study/StudyDetailResponseDto.java
@@ -5,28 +5,41 @@ import com.donothing.swithme.domain.StudyStatus;
 import com.donothing.swithme.domain.StudyType;
 import com.donothing.swithme.dto.member.MemberInfoResponseDto;
 import com.fasterxml.jackson.annotation.JsonFormat;
-import java.time.LocalDateTime;
+
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 
 @Getter
 public class StudyDetailResponseDto {
+    @ApiModelProperty(value = "스터디 아이디")
     private Long studyId;
-
+    
+    @ApiModelProperty(value = "스터디 생성자")
     private MemberInfoResponseDto createdMember;
 
+    @ApiModelProperty(value = "스터디 제목")
     private String title;
 
+    @ApiModelProperty(value = "스터디 타입")
     private StudyType studyType; // ONLINE, OFFLINE
 
+    @ApiModelProperty(value = "목표 인원수")
     private int numberOfMembers; // 목표 인원수
 
+    @ApiModelProperty(value = "남은 인원수")
+    private int remainingNumber; // 참여 가능한 남은 인원수
+
+    @ApiModelProperty(value = "스터디 정보")
     private String studyInfo;
 
+    @ApiModelProperty(value = "스터디 상태")
     private StudyStatus studyStatus; // CURR, COMP, END
 
+    @ApiModelProperty(value = "스터디 시작 날")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private String dateStudyStart;
 
+    @ApiModelProperty(value = "스터디 마감 날")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private String dateStudyEnd;
 
@@ -40,6 +53,7 @@ public class StudyDetailResponseDto {
         this.title = study.getTitle();
         this.studyType = study.getStudyType();
         this.numberOfMembers = study.getNumberOfMembers();
+        this.remainingNumber = study.getRemainingNumber();
         this.studyInfo = study.getStudyInfo();
         this.studyStatus = study.getStudyStatus();
         this.dateStudyStart = study.getDateStudyStart();

--- a/src/main/java/com/donothing/swithme/dto/study/StudyRegisterRequestDto.java
+++ b/src/main/java/com/donothing/swithme/dto/study/StudyRegisterRequestDto.java
@@ -7,8 +7,6 @@ import com.donothing.swithme.domain.StudyType;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
-
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -63,6 +61,7 @@ public class StudyRegisterRequestDto {
                 .studyType(studyType)
                 .studyStatus(StudyStatus.CURR)
                 .numberOfMembers(numberOfMembers)
+                .remainingNumber(numberOfMembers - 1)
                 .studyInfo(studyInfo)
                 .dateStudyStart(dateStudyStart)
                 .dateStudyEnd(dateStudyEnd)

--- a/src/main/java/com/donothing/swithme/dto/study/StudyRegisterRequestDto.java
+++ b/src/main/java/com/donothing/swithme/dto/study/StudyRegisterRequestDto.java
@@ -14,8 +14,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
-
 @Getter
 @Setter
 @NoArgsConstructor
@@ -37,23 +35,25 @@ public class StudyRegisterRequestDto {
 
     @NotNull(message = "멤버 수 값은 필수입니다.")
     @Min(1)
-    @ApiModelProperty(value = "제목", required = true)
+    @ApiModelProperty(value = "멤버 수", required = true)
     private int numberOfMembers;
 
     @NotNull(message = "지역 코드는 필수입니다.")
-    @ApiModelProperty(value = "제목", example = "1", required = true)
+    @ApiModelProperty(value = "지역 코드", example = "1", required = true)
     private String regionCode;
 
     @NotNull(message = "스터디 정보는 필수입니다.")
-    @ApiModelProperty(value = "제목", required = true)
+    @ApiModelProperty(value = "스터디 정보", required = true)
     private String studyInfo;
 
     @NotNull(message = "스터디 시작날짜는 필수입니다.")
     @Pattern(regexp = "^\\d{8}$", message="스터디 시작일은 yyyyMMdd 형식의 날짜로 입력해주세요.")
+    @ApiModelProperty(value = "스터디 시작날짜", required = true)
     private String dateStudyStart;
 
     @NotNull(message = "스터디 마감날짜는 필수입니다.")
     @Pattern(regexp = "^\\d{8}$", message="스터디 시작일은 yyyyMMdd 형식의 날짜로 입력해주세요.")
+    @ApiModelProperty(value = "스터디 마감날짜", required = true)
     private String dateStudyEnd;
 
     public Study toEntity() {

--- a/src/main/java/com/donothing/swithme/dto/study/StudySearchRequest.java
+++ b/src/main/java/com/donothing/swithme/dto/study/StudySearchRequest.java
@@ -1,8 +1,10 @@
 package com.donothing.swithme.dto.study;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class StudySearchRequest {
     private String category;
     private String detailCategory;

--- a/src/main/java/com/donothing/swithme/dto/study/StudySearchRequest.java
+++ b/src/main/java/com/donothing/swithme/dto/study/StudySearchRequest.java
@@ -1,14 +1,24 @@
 package com.donothing.swithme.dto.study;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class StudySearchRequest {
+    @ApiModelProperty(value = "카테고리")
     private String category;
+
+    @ApiModelProperty(value = "세부 카테고리")
     private String detailCategory;
+
+    @ApiModelProperty(value = "지역(구)")
     private String gu;
+
+    @ApiModelProperty(value = "지역(동)")
     private String dong;
+
+    @ApiModelProperty(value = "지역(제목)")
     private String title;
 }

--- a/src/main/java/com/donothing/swithme/dto/study/StudyUpdateRequestDto.java
+++ b/src/main/java/com/donothing/swithme/dto/study/StudyUpdateRequestDto.java
@@ -2,33 +2,47 @@ package com.donothing.swithme.dto.study;
 
 import com.donothing.swithme.domain.StudyStatus;
 import com.donothing.swithme.domain.StudyType;
+
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class StudyUpdateRequestDto {
-    @NotBlank(message = "제목 값은 필수입니다.")
+    @NotNull(message = "제목 값은 필수입니다.")
     private String title;
 
-    @NotBlank(message = "스터디 타입 값은 필수입니다.")
+    @NotNull(message = "스터디 타입 값은 필수입니다.")
+    @ApiModelProperty(value = "스터디 타입", required = true, allowableValues = "ONLINE, OFFLINE")
     private StudyType studyType;
 
-    @NotBlank(message = "스터디원 수는 필수입니다.")
+    @NotNull(message = "멤버 수 값은 필수입니다.")
+    @Min(1)
+    @ApiModelProperty(value = "멤버 수", required = true)
     private int numberOfMembers;
 
     @NotNull(message = "스터디 정보가 null값일 수 없습니다.")
+    @ApiModelProperty(value = "스터디 정보", required = true)
     private String studyInfo;
 
-    @NotBlank(message = "스터디 타입 값은 필수입니다.")
+    @NotNull(message = "스터디 상태 값은 필수입니다.")
+    @ApiModelProperty(value = "스터디 상태", required = true, allowableValues = "CURR, COMP, END")
     private StudyStatus studyStatus;
 
+    @NotNull(message = "스터디 시작날짜는 필수입니다.")
     @Pattern(regexp = "^\\d{8}$", message="스터디 시작일은 yyyyMMdd 형식의 날짜로 입력해주세요.")
+    @ApiModelProperty(value = "스터디 시작날짜", required = true)
     private String dateStudyStart;
 
-    @Pattern(regexp = "^\\d{8}$", message="스터디 종료일은 yyyyMMdd 형식의 날짜로 입력해주세요.")
+    @NotNull(message = "스터디 마감날짜는 필수입니다.")
+    @Pattern(regexp = "^\\d{8}$", message="스터디 시작일은 yyyyMMdd 형식의 날짜로 입력해주세요.")
+    @ApiModelProperty(value = "스터디 마감날짜", required = true)
     private String dateStudyEnd;
+
 }

--- a/src/main/java/com/donothing/swithme/repository/MemberStudyRepository.java
+++ b/src/main/java/com/donothing/swithme/repository/MemberStudyRepository.java
@@ -1,0 +1,8 @@
+package com.donothing.swithme.repository;
+
+import com.donothing.swithme.domain.MemberStudy;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberStudyRepository extends JpaRepository<MemberStudy, Long> {
+    boolean existsByStudy_StudyIdAndMember_MemberId(Long studyId, Long memberId);
+}

--- a/src/main/java/com/donothing/swithme/repository/StudyCustomRepository.java
+++ b/src/main/java/com/donothing/swithme/repository/StudyCustomRepository.java
@@ -1,10 +1,12 @@
 package com.donothing.swithme.repository;
 
 import com.donothing.swithme.domain.Study;
+import com.donothing.swithme.dto.study.StudyDetailResponseDto;
+import com.donothing.swithme.dto.study.StudyListResponseDto;
 import com.donothing.swithme.dto.study.StudySearchRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface StudyCustomRepository {
-    Page<Study> searchStudies(StudySearchRequest request, Pageable pageable);
+    Page<StudyDetailResponseDto> searchStudies(StudySearchRequest request, Pageable pageable);
 }

--- a/src/main/java/com/donothing/swithme/repository/StudyCustomRepositoryImpl.java
+++ b/src/main/java/com/donothing/swithme/repository/StudyCustomRepositoryImpl.java
@@ -51,11 +51,10 @@ public class StudyCustomRepositoryImpl implements StudyCustomRepository {
                 .limit(pageable.getPageSize()) // 한번 조회할 때 몇개까지
                 .fetch();
 
-//        List<StudyDetailResponseDto> result = studyList.stream().map(StudyDetailResponseDto::new).collect(Collectors.toList());
+        List<StudyDetailResponseDto> result = studyList.stream().map(StudyDetailResponseDto::new).collect(Collectors.toList());
         JPAQuery<Long> countQuery = queryFactory.select(study.count())
                 .from(study);
 
-        System.out.println(result);
         return PageableExecutionUtils.getPage(result, pageable, countQuery::fetchOne);
     }
 

--- a/src/main/java/com/donothing/swithme/repository/StudyCustomRepositoryImpl.java
+++ b/src/main/java/com/donothing/swithme/repository/StudyCustomRepositoryImpl.java
@@ -29,11 +29,12 @@ public class StudyCustomRepositoryImpl implements StudyCustomRepository {
     }
 
     @Override
-    public Page<Study> searchStudies(StudySearchRequest request, Pageable pageable) {
+    public Page<StudyDetailResponseDto> searchStudies(StudySearchRequest request, Pageable pageable) {
         QStudy qStudy = new QStudy("study");
-        QMember qMember = new QMember("member");
 
-        List<Study> studyList = queryFactory.select(Projections.fields(Study.class,
+        List<Study> studyList =
+                queryFactory.select(
+                        Projections.fields(Study.class,
                         qStudy.studyId,
                         qStudy.title,
                         qStudy.studyInfo,
@@ -46,15 +47,16 @@ public class StudyCustomRepositoryImpl implements StudyCustomRepository {
                         qStudy.member.as("member")))  // study.member 추가
                 .from(study)
                 .where(titleEq(request.getTitle()))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset()) // 스킵하고 몇번째부터 시작할건지
+                .limit(pageable.getPageSize()) // 한번 조회할 때 몇개까지
                 .fetch();
 
         List<StudyDetailResponseDto> result = studyList.stream().map(StudyDetailResponseDto::new).collect(Collectors.toList());
         JPAQuery<Long> countQuery = queryFactory.select(study.count())
                 .from(study);
 
-        return PageableExecutionUtils.getPage(studyList, pageable, countQuery::fetchOne);
+        System.out.println(result);
+        return PageableExecutionUtils.getPage(result, pageable, countQuery::fetchOne);
     }
 
     private BooleanExpression titleEq(String title) {

--- a/src/main/java/com/donothing/swithme/repository/StudyRepository.java
+++ b/src/main/java/com/donothing/swithme/repository/StudyRepository.java
@@ -2,6 +2,14 @@ package com.donothing.swithme.repository;
 
 import com.donothing.swithme.domain.Study;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import javax.persistence.LockModeType;
+import java.util.Optional;
 
 public interface StudyRepository extends JpaRepository<Study, Long>, StudyCustomRepository {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM Study s WHERE s.studyId = :studyId ")
+    Optional<Study> findByIdWithPessimistic(Long studyId);
 }

--- a/src/main/java/com/donothing/swithme/service/StudyService.java
+++ b/src/main/java/com/donothing/swithme/service/StudyService.java
@@ -1,16 +1,13 @@
 package com.donothing.swithme.service;
 
-import com.donothing.swithme.common.PagingData;
 import com.donothing.swithme.domain.Study;
 import com.donothing.swithme.dto.study.*;
 import com.donothing.swithme.repository.StudyRepository;
-import java.util.List;
 import java.util.NoSuchElementException;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -38,7 +35,7 @@ public class StudyService {
         return null;
     }
 
-    public Page<Study> getStudies(StudySearchRequest condition, Pageable pageable) {
+    public Page<StudyDetailResponseDto> getStudies(StudySearchRequest condition, Pageable pageable) {
         return studyRepository.searchStudies(condition, pageable);
     }
 

--- a/src/main/java/com/donothing/swithme/service/StudyService.java
+++ b/src/main/java/com/donothing/swithme/service/StudyService.java
@@ -33,12 +33,10 @@ public class StudyService {
         Study study = validationAndGetStudy(studyId);
         return new StudyDetailResponseDto(study);
     }
-
-    public StudyDetailResponseDto updateStudy(String studyId, StudyUpdateRequestDto reuqest) {
+    @Transactional
+    public void updateStudy(String studyId, StudyUpdateRequestDto reuqest) {
         Study study = validationAndGetStudy(studyId);
         study.update(reuqest);
-
-        return null;
     }
 
     public Page<StudyDetailResponseDto> getStudies(StudySearchRequest condition, Pageable pageable) {
@@ -66,7 +64,6 @@ public class StudyService {
         }
 
         return comments;
-
     }
 
     public Study validationAndGetStudy(String studyId) {
@@ -74,5 +71,31 @@ public class StudyService {
             log.error("존재하지 않는 스터디 입니다. studyId = " + studyId);
             return new NoSuchElementException("존재하지 않는 스터디 입니다. ");
         });
+    }
+
+    public void comment(String studyId, StudyCommentReqeustDto reuqest) {
+        Study study = validationAndGetStudy(studyId);
+        commentRepository.save(
+                reuqest.toEntity(reuqest.getMemberId(),
+                        Long.parseLong(studyId)));
+    }
+    @Transactional
+    public void updateComment(StudyCommentUpdateRequestDto request) {
+        Comment comment = commentRepository.findById(request.getCommentId()).orElseThrow(() -> {
+            log.error("존재하지 않는 댓글 입니다. studyId = " + request.getCommentId());
+            return new NoSuchElementException("존재하지 않는 댓글 입니다. ");
+        });
+
+        comment.update(request);
+    }
+
+    @Transactional
+    public void deleteComment(Long commentId) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> {
+            log.error("존재하지 않는 댓글 입니다. studyId = " + commentId);
+            return new NoSuchElementException("존재하지 않는 댓글 입니다. ");
+        });
+
+        commentRepository.delete(comment);
     }
 }

--- a/src/main/java/com/donothing/swithme/service/StudyService.java
+++ b/src/main/java/com/donothing/swithme/service/StudyService.java
@@ -66,12 +66,12 @@ public class StudyService {
 
         // 각 댓글에 대해 대댓글 추가
         for (StudyCommentListResponseDto comment : comments) {
-            List<StudyCommentListResponseDto> recommnet = allComments.stream()
+            List<StudyCommentListResponseDto> recomment = allComments.stream()
                     .filter(c -> c.getCommentTag() != null && c.getCommentTag().equals(comment.getCommentId()))
                     .map(StudyCommentListResponseDto::new)
                     .collect(Collectors.toList());
 
-            comment.setRecommnet(recommnet);
+            comment.setRecomment(recomment);
         }
 
         return comments;

--- a/src/test/java/com/donothing/swithme/CommentServiceTest.java
+++ b/src/test/java/com/donothing/swithme/CommentServiceTest.java
@@ -1,11 +1,11 @@
 package com.donothing.swithme;
 
+import com.donothing.swithme.domain.Comment;
 import com.donothing.swithme.domain.Study;
 import com.donothing.swithme.dto.study.JoinStudyRequest;
-import com.donothing.swithme.repository.MemberStudyRepository;
-import com.donothing.swithme.repository.StudyRepository;
+import com.donothing.swithme.dto.study.StudyCommentReqeustDto;
+import com.donothing.swithme.repository.CommentRepository;
 import com.donothing.swithme.service.StudyService;
-import jdk.jshell.spi.ExecutionControl;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,33 +13,48 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
 @SpringBootTest
 @RunWith(SpringRunner.class)
 public class CommentServiceTest {
-
     @Autowired
     private StudyService studyService;
 
     @Autowired
-    private StudyRepository studyRepository;
+    private CommentRepository commentRepository;
 
     @Test
     public void 댓글달기() {
         // given
-        JoinStudyRequest request = JoinStudyRequest.builder()
-                .studyId(1L)
+        String studyId = "1";
+        StudyCommentReqeustDto request = StudyCommentReqeustDto.builder()
+                .recommentId(null)
+                .comment("댓글 달았지롱")
                 .memberId(1L)
                 .build();
 
         // when
-        studyService.joinStudy(request);
-        Study study = studyRepository.findById(1L).orElseThrow();
+        studyService.comment(studyId, request);
+        Comment comment = commentRepository.findById(1L).orElseThrow();
 
         // then
-        Assert.assertEquals(9, study.getRemainingNumber());
+        Assert.assertEquals("댓글 달았지롱", comment.getComment());
+    }
+
+    @Test
+    public void 대댓글달기() {
+        // given
+        String studyId = "1";
+        StudyCommentReqeustDto request = StudyCommentReqeustDto.builder()
+                .recommentId(1L)
+                .comment("대댓글 달았지롱")
+                .memberId(1L)
+                .build();
+
+        // when
+        studyService.comment(studyId, request);
+        Comment comment = commentRepository.findById(2L).orElseThrow();
+
+        // then
+        Assert.assertEquals("대댓글 달았지롱", comment.getComment());
     }
 }

--- a/src/test/java/com/donothing/swithme/CommentServiceTest.java
+++ b/src/test/java/com/donothing/swithme/CommentServiceTest.java
@@ -1,0 +1,45 @@
+package com.donothing.swithme;
+
+import com.donothing.swithme.domain.Study;
+import com.donothing.swithme.dto.study.JoinStudyRequest;
+import com.donothing.swithme.repository.MemberStudyRepository;
+import com.donothing.swithme.repository.StudyRepository;
+import com.donothing.swithme.service.StudyService;
+import jdk.jshell.spi.ExecutionControl;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@SpringBootTest
+@RunWith(SpringRunner.class)
+public class CommentServiceTest {
+
+    @Autowired
+    private StudyService studyService;
+
+    @Autowired
+    private StudyRepository studyRepository;
+
+    @Test
+    public void 댓글달기() {
+        // given
+        JoinStudyRequest request = JoinStudyRequest.builder()
+                .studyId(1L)
+                .memberId(1L)
+                .build();
+
+        // when
+        studyService.joinStudy(request);
+        Study study = studyRepository.findById(1L).orElseThrow();
+
+        // then
+        Assert.assertEquals(9, study.getRemainingNumber());
+    }
+}

--- a/src/test/java/com/donothing/swithme/StudyControllerTest.java
+++ b/src/test/java/com/donothing/swithme/StudyControllerTest.java
@@ -1,0 +1,117 @@
+package com.donothing.swithme;
+
+import com.donothing.swithme.domain.Study;
+import com.donothing.swithme.dto.study.JoinStudyRequest;
+import com.donothing.swithme.repository.MemberStudyRepository;
+import com.donothing.swithme.repository.StudyRepository;
+import com.donothing.swithme.service.StudyService;
+import jdk.jshell.spi.ExecutionControl;
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@SpringBootTest
+@RunWith(SpringRunner.class)
+public class StudyControllerTest {
+
+    @Autowired
+    private StudyService studyService;
+
+    @Autowired
+    private StudyRepository studyRepository;
+
+    @Autowired
+    private MemberStudyRepository memberStudyRepository;
+
+    @Test
+    public void 동시에_스터디_참여_요청() throws InterruptedException {
+        // given
+        int threadCnt = 9;
+
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCnt);
+        for (int i = 0; i < threadCnt; i++) {
+            JoinStudyRequest request = JoinStudyRequest.builder()
+                    .studyId(1L)
+                    .memberId(2L + i)
+                    .build();
+
+            executorService.submit(() -> {
+                try {
+                    studyService.joinStudy(request);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        Study study = studyRepository.findById(1L).orElseThrow();
+        Assert.assertEquals(0, study.getRemainingNumber());
+    }
+
+    @Test
+    public void 스터디_참여() {
+        // given
+        JoinStudyRequest request = JoinStudyRequest.builder()
+                .studyId(1L)
+                .memberId(1L)
+                .build();
+
+        // when
+        studyService.joinStudy(request);
+        Study study = studyRepository.findById(1L).orElseThrow();
+
+        // then
+        Assert.assertEquals(9, study.getRemainingNumber());
+    }
+
+    @Test
+    public void 이미_스터디에_참여한사람은_불가능하다() {
+        // given
+        JoinStudyRequest request = JoinStudyRequest.builder()
+                .studyId(1L)
+                .memberId(1L)
+                .build();
+
+        // then
+        Assert.assertThrows(IllegalStateException.class, () -> {
+            studyService.joinStudy(request);
+        });
+    }
+    
+    @Test
+    public void 스터디에_참여하지않은사람은_true() {
+        // given
+        Long studyId = 1L;
+        Long memberId = 1L;
+
+        // when
+        boolean result = memberStudyRepository.existsByStudy_StudyIdAndMember_MemberId(studyId, memberId);
+
+        // then
+        Assert.assertTrue(result);
+    }
+
+    @Test
+    public void 스터디에_참여하지않은사람은_false() {
+        // given
+        Long studyId = 1L;
+        Long memberId = 2L;
+
+        // when
+        boolean result = memberStudyRepository.existsByStudy_StudyIdAndMember_MemberId(studyId, memberId);
+
+        // then
+        Assert.assertFalse(result);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,33 @@
+spring:
+  datasource:
+    # 각자 PC에 만들어둔 DB 이름을 3306/( )?에 넣어 사용
+    url: jdbc:mysql://localhost:3306/swithme
+    # mysql에 생성한 사용자 계정 정보 사용
+    username: root
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      #    ddl-auto:
+      ddl-auto: none
+    #      ddl-auto: create
+    properties:
+      hibernate:
+        #        show_sql: true
+        format_sql: true
+
+  redis:
+    host: localhost
+    port: 6379
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+
+jwt:
+  secret-key: 202307teamDoNothingSwithmeLetsGooooOOoMSCUK202403Wppd29vbi1zcHJpbmctYm9vdC1zZWN1cml0eS1qd3QtdHV0b3JpYWwK
+


### PR DESCRIPTION
## ✨ 작업 내용
- 스터디 참여 API 추가
- 스터디 남은 인원 컬럼 추가
- 스터디 북마크 request 변경
- 스터디 댓글 조회 시 formatting
- closed(#23)

## 🌈 상세 설명
- 스터디 참여 시 동시성 이슈로 인한 Pessimistic Lock 
- 스터디 생성 시 방장도 스터디멤버에 추가하는 로직 추가
- 에러 시 에러메시지 볼 수 있도록 예외처리 기능 추가

## 참고
- [[Spring] 스프링에서 ControllerAdvice와 ExceptionHandler를 사용해서 어떻게 예외처리를 할 수 있을까?](https://m.blog.naver.com/sosow0212/223079365692)
- [@RestControllerAdvice를 이용한 예외처리](https://velog.io/@woosim34/RestControllerAdvice%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-%EC%98%88%EC%99%B8%EC%B2%98%EB%A6%AC)
- [JPA exists 쿼리 성능 개선](https://jojoldu.tistory.com/516)
- [동시성 문제 - 인강정리내용](https://hye0e.notion.site/548d441db81d4c9393bca011dd391567)