### PR TITLE
Feat: 챌린지 인증 승인(방장용) API

### DIFF
--- a/src/main/java/com/donothing/swithme/controller/ChallengeController.java
+++ b/src/main/java/com/donothing/swithme/controller/ChallengeController.java
@@ -88,4 +88,15 @@ public class ChallengeController {
         return new ResponseEntity<>(new ResponseDto<>(201, "챌린지 데일리 인증 성공", null),
                 HttpStatus.CREATED);
     }
+
+    @PutMapping("/{challengeLogId}/{approveStatus}")
+    @ApiOperation(value = "챌린지 인증 승인하기", notes = "챌린지 방장 인증 여부 승인용 API 입니다.")
+    public ResponseEntity<ResponseDto<Void>> approveChallengeLog(
+            @PathVariable("challengeLogId") String challengeLogId,
+            @PathVariable("approveStatus") String approveStatus) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        challengeService.approveChallengeLog(memberId, challengeLogId, approveStatus);
+        return new ResponseEntity<>(new ResponseDto<>(200, "챌린지 인증 승인 성공", null),
+                HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/donothing/swithme/domain/ChallengeLog.java
+++ b/src/main/java/com/donothing/swithme/domain/ChallengeLog.java
@@ -39,4 +39,8 @@ public class ChallengeLog extends BaseTimeEntity {
     public void setChallengeLogStatus(ChallengeLogStatus challengeLogStatus) {
         this.challengeLogStatus = challengeLogStatus;
     }
+
+    public void setChallengeLogApproveStatus(ApproveStatus challengeLogApproveStatus) {
+        this.challengeLogApproveStatus = challengeLogApproveStatus;
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
 
     properties:
       hibernate:


### PR DESCRIPTION
## ✨ 작업 내용
- close #42 

## 🌈 상세 설명
- 챌린지로그 아이디, 상태값(APPROVE 또는 DENY) 받아서 넘김
- 챌린지로그 아이디로 챌린지 검증
- 로그인 아이디로 방장 검증
- 방장인 경우, 상태값 비교하여 승인/거절 값 변경