### PR TITLE
Feat: 스터디 멤버 조회 시 권한 추가

### DIFF
--- a/src/main/java/com/donothing/swithme/domain/StudyRole.java
+++ b/src/main/java/com/donothing/swithme/domain/StudyRole.java
@@ -1,0 +1,25 @@
+package com.donothing.swithme.domain;
+
+public enum StudyRole {
+    LEADER("리더"),
+    STUDY_MEMBER("스터디원");
+
+    private final String description;
+
+    StudyRole(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public static StudyRole fromString(String text) {
+        for (StudyRole role : StudyRole.values()) {
+            if (role.description.equalsIgnoreCase(text) || role.name().equalsIgnoreCase(text)) {
+                return role;
+            }
+        }
+        throw new IllegalArgumentException("No constant with text " + text + " found");
+    }
+}

--- a/src/main/java/com/donothing/swithme/dto/member/MemberListResponseDto.java
+++ b/src/main/java/com/donothing/swithme/dto/member/MemberListResponseDto.java
@@ -1,6 +1,7 @@
 package com.donothing.swithme.dto.member;
 
 import com.donothing.swithme.domain.MemberStudy;
+import com.donothing.swithme.domain.StudyRole;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,10 +12,25 @@ public class MemberListResponseDto {
     private Long memberId;
     private String nickname;
     private String s3Url;
+    private StudyRole studyRole;
 
     public MemberListResponseDto(MemberStudy memberStudy) {
+        if (memberStudy == null || memberStudy.getMember() == null ||
+                memberStudy.getStudy() == null) {
+            throw new IllegalArgumentException("Invalid MemberStudy data");
+        }
+
         this.memberId = memberStudy.getMember().getMemberId();
         this.nickname = memberStudy.getMember().getNickname();
         this.s3Url = memberStudy.getMember().getS3Url();
+        this.studyRole = determineStudyRole(memberStudy);
+    }
+
+    private StudyRole determineStudyRole(MemberStudy memberStudy) {
+        Long studyLeaderId = memberStudy.getStudy().getMember().getMemberId();
+        Long currentMemberId = memberStudy.getMember().getMemberId();
+
+        return studyLeaderId.equals(currentMemberId) ?
+                StudyRole.LEADER : StudyRole.STUDY_MEMBER;
     }
 }

--- a/src/main/java/com/donothing/swithme/dto/study/StudyDetailResponseDto.java
+++ b/src/main/java/com/donothing/swithme/dto/study/StudyDetailResponseDto.java
@@ -7,6 +7,7 @@ import com.donothing.swithme.dto.member.MemberInfoResponseDto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import io.swagger.annotations.ApiModelProperty;
+import java.util.List;
 import lombok.Getter;
 
 import javax.persistence.Column;
@@ -52,6 +53,9 @@ public class StudyDetailResponseDto {
 
     @ApiModelProperty(value = "스터디 썸네일 이미지")
     private String s3Url;
+
+    @ApiModelProperty(value = "스터디 참여중인 멤버")
+    private List<MemberInfoResponseDto> studyMemberList;
 
     public StudyDetailResponseDto(Study study, long commentCnt) {
         this.studyId = study.getStudyId();


### PR DESCRIPTION
## ✨ 작업 내용
- 스터디 내 멤버 조회 시 권한 필드 추가 (closed #111 )

## 🌈 상세 설명
- 스터디 생성자와 멤버아이디가 같으면 리더로 내려주고 그 외에는 스터디원으로 내려준다. 